### PR TITLE
Initial STM32WBx5 support.

### DIFF
--- a/src/devices/registry.rs
+++ b/src/devices/registry.rs
@@ -736,4 +736,27 @@ pub const REGISTRY: &[Device] = &[
         log_swo: None,
         log_dso: Some(LogDso { krate: crates::Dso::Nrf91, features: &[] }),
     },
+    Device {
+        name: "stm32wbx5",
+        target: "thumbv7em-none-eabihf",
+        flash_origin: 0x0800_0000,
+        ram_origin: 0x2000_0000,
+        platform_crate: PlatformCrate {
+            krate: crates::Platform::Cortexm,
+            flag: "cortex_m4f_r0p1",
+            features: &["floating-point-unit"],
+        },
+        bindings_crate: BindingsCrate {
+            krate: crates::Bindings::Stm32,
+            flag: "stm32wbx5",
+            features: &[],
+        },
+        probe_bmp: Some(ProbeBmp { device: "stm32wbx5" }),
+        probe_openocd: Some(ProbeOpenocd {
+            arguments: &["-f", "interface/stlink.cfg", "-f", "target/stm32wbx5.cfg"],
+        }),
+        probe_jlink: None,
+        log_swo: Some(LogSwo { reset_freq: 4_000_000 }),
+        log_dso: None,
+    },
 ];


### PR DESCRIPTION
I've been toying around with some [WB series STMs](https://www.st.com/en/microcontrollers-microprocessors/stm32wb-series.html), which supports concurrent Bluetooth and 802.15.4 comms.

I had been thinking about writing my own async reactor for those MCUs, but it seems like Drone has done most of the work already! This work looks very exciting for me.

This commit adds the STM32WBx5 to the device list and code generator. Feel free to let this hang around until I submit something for `drone-cortex-m`!

EDIT: [Reference manual](https://www.st.com/resource/en/reference_manual/dm00318631.pdf).

- [x] A nitpick: I think x in Stm32Wbx5 should be in lower case. This will be compatible with the Inflector crate rules. Because Stm32WbX5 would be lower cased to stm32wb_x5.
- [x] Actually test on HW.