### PR TITLE
Initial cc2538 support

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -13,6 +13,7 @@ pub enum Platform {
 pub enum Bindings {
     Nrf,
     Stm32,
+    TiSl,
 }
 
 /// Drone Serial Output implementation crates.
@@ -44,6 +45,7 @@ impl Bindings {
         match self {
             Self::Nrf => "nrf",
             Self::Stm32 => "stm32",
+            Self::TiSl => "tisl",
         }
     }
 
@@ -52,6 +54,7 @@ impl Bindings {
         match self {
             Self::Nrf => "nrf_mcu",
             Self::Stm32 => "stm32_mcu",
+            Self::TiSl => "tisl_mcu",
         }
     }
 }

--- a/src/devices/registry.rs
+++ b/src/devices/registry.rs
@@ -736,4 +736,34 @@ pub const REGISTRY: &[Device] = &[
         log_swo: None,
         log_dso: Some(LogDso { krate: crates::Dso::Nrf91, features: &[] }),
     },
+    Device {
+        name: "cc2538",
+        target: "thumbv7m-none-eabi",
+        flash_origin: 0x0020_0000,
+        ram_origin: 0x2000_0000,
+        platform_crate: PlatformCrate {
+            krate: crates::Platform::Cortexm,
+            flag: "cortexm3_r1p0",
+            features: &[],
+        },
+        bindings_crate: BindingsCrate {
+            krate: crates::Bindings::TiSl,
+            flag: "cc2538",
+            features: &[],
+        },
+        probe_bmp: None,
+        probe_openocd: Some(ProbeOpenocd {
+            arguments: &[
+                "-f",
+                "interface/xds110.cfg",
+                "-c",
+                "target select jtag",
+                "-f",
+                "target/cc2538.cfg",
+            ],
+        }),
+        probe_jlink: None,
+        log_swo: Some(LogSwo { reset_freq: 32_000_000 }),
+        log_dso: None,
+    },
 ];

--- a/src/devices/registry.rs
+++ b/src/devices/registry.rs
@@ -749,7 +749,7 @@ pub const REGISTRY: &[Device] = &[
         bindings_crate: BindingsCrate {
             krate: crates::Bindings::TiSl,
             flag: "cc2538",
-            features: &[],
+            features: &["uart"],
         },
         probe_bmp: None,
         probe_openocd: Some(ProbeOpenocd {


### PR DESCRIPTION
This adds support for the [CC2538](https://www.ti.com/product/CC2538?keyMatch=CC2538&tisearch=Search-EN-everything&usecase=part-number) chip from TI.
It is part of the SimpleLink platforms.