### PR TITLE
`drone new` don't use rustup 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ description = """
 CLI utility for Drone, an Embedded Operating System.
 """
 
+[features]
+default = []
+no-rustup = []
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -112,10 +112,16 @@ fn new_heap(size: u32, pools: u32) -> Result<String> {
 }
 
 fn cargo_new(path: &Path, toolchain: &str) -> Result<()> {
-    let mut rustup = Command::new("rustup");
-    rustup.arg("run").arg(toolchain);
-    rustup.arg("cargo").arg("new").arg("--bin").arg(path);
-    run_command(rustup)
+    let mut command = if cfg!(feature = "no-rustup") {
+        Command::new("cargo")
+    } else {
+        let mut rustup = Command::new("rustup");
+        rustup.arg("run").arg(toolchain);
+        rustup.arg("cargo");
+        rustup
+    };
+    command.arg("new").arg("--bin").arg(path);
+    run_command(command)
 }
 
 fn src_main_rs(path: &Path, color: Color) -> Result<()> {


### PR DESCRIPTION
This PR adds a feature to use cargo directly instead of rustup run cargo when using `drone new`

I don't have rustup on my environment so drone new does not work for me without this.
I'm still undecided whether to remove or not rustup from the template as well, if you think it should be I can do it.