### PR TITLE
Disable Handlebar escaping some characters when creating Cargo.toml

### DIFF
--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -156,6 +156,7 @@ pub fn register(handlebars: &mut Handlebars<'_>) {
     handlebars.register_helper("replace", Box::new(Replace));
     handlebars.register_helper("if-any-of", Box::new(IfAnyOf));
     handlebars.register_helper("if-includes", Box::new(IfIncludes));
+    handlebars.register_escape_fn(handlebars::no_escape);
 }
 
 /// Clears all variables.


### PR DESCRIPTION
This was causing an issue when creating a new drone project. Handlebars
escapes &"<> characters by default and generated the following `Cargo.toml`:
```
[package]
name &#x3D; &quot;test_project&quot;
version &#x3D; &quot;0.1.0&quot;
authors &#x3D; [&quot;Thibaut Vandervelden &lt;email@domain.com&gt;&quot;]
edition &#x3D; &quot;2018&quot;
resolver &#x3D; &quot;2&quot;
```
 This PR disables escaping of these characters.