### PR TITLE
Fix quoting in 'name' in Justfile template

### DIFF
--- a/src/templates/new/Justfile.hbs
+++ b/src/templates/new/Justfile.hbs
@@ -1,7 +1,7 @@
 export DRONE_RUSTFLAGS := '--cfg {{platform_flag_name}}="{{platform_flag}}" --cfg {{bindings_flag_name}}="{{bindings_flag}}"'
 target := '{{device_target}}'
 features := ''
-name := `basename $(pwd)`
+name := `basename "$(pwd)"`
 release_bin := "target/" + target + "/release/" + name
 
 # Install dependencies


### PR DESCRIPTION
Commands like `just flash` do not work in generated projects when there is a whitespace in the path to the project.

For example when using `--probe openocd`
`~/Projects/Rust experiments/hello_world $ just flash` produces following error:
`invalid subcommand "write_image erase target/thumbv7em-none-eabihf/release/Rust 0"`
due to the **name** in Justfile being incorrectly determined to be _Rust_.

There have to be double quotes around _$(pwd)_.