### PR TITLE
Modify .cargo/config template to contain target and flags

### DIFF
--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -58,7 +58,7 @@ pub fn run(cmd: NewCmd, color: Color) -> Result<()> {
     drone_toml(&path, device, flash_size, ram_size, &heap, probe, log, &registry, color)?;
     justfile(&path, device, &registry, color)?;
     rust_toolchain(&path, &toolchain, &registry, color)?;
-    cargo_config(&path, &registry, color)?;
+    cargo_config(&path, device, &registry, color)?;
     gitignore(&path, &registry, color)?;
 
     Ok(())
@@ -240,12 +240,12 @@ fn rust_toolchain(
     Ok(())
 }
 
-fn cargo_config(path: &Path, registry: &Registry<'_>, color: Color) -> Result<()> {
+fn cargo_config(path: &Path, device: &Device, registry: &Registry<'_>, color: Color) -> Result<()> {
     let path = path.join(".cargo");
     create_dir(&path)?;
     let path = path.join("config");
     let mut file = File::create(&path)?;
-    file.write_all(registry.new_cargo_config()?.as_bytes())?;
+    file.write_all(registry.new_cargo_config(device)?.as_bytes())?;
     print_created(".cargo/config", color);
     Ok(())
 }

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -208,9 +208,17 @@ impl Registry<'_> {
     }
 
     /// Renders `.cargo/config`.
-    pub fn new_cargo_config(&self) -> Result<String> {
+    pub fn new_cargo_config(&self, device: &Device) -> Result<String> {
+        let data = json!({
+            "device_target": device.target,
+            "platform_flag_name": device.platform_crate.krate.flag_name(),
+            "bindings_flag_name": device.bindings_crate.krate.flag_name(),
+            "platform_flag": device.platform_crate.flag,
+            "bindings_flag": device.bindings_crate.flag,
+        });
+
         helpers::clear_vars();
-        Ok(self.0.render("new/_cargo/config", &())?)
+        Ok(self.0.render("new/_cargo/config", &data)?)
     }
 
     /// Renders `.gitignore`.

--- a/src/templates/new/_cargo/config.hbs
+++ b/src/templates/new/_cargo/config.hbs
@@ -1,3 +1,12 @@
+[build]
+target = "{{device_target}}"
+
+[target.{{device_target}}]
+rustflags = [
+    '--cfg', '{{platform_flag_name}}="{{platform_flag}}"',
+    '--cfg', '{{bindings_flag_name}}="{{bindings_flag}}"'
+]
+
 [target.'cfg(target_os = "none")']
 rustflags = [
     "-C", "linker=drone-ld",


### PR DESCRIPTION
.cargo/config will now contain the correct target and the needed flags
used by Drone.
This is helpful information for rust-analyzer or RLS.