### PR TITLE
Streamline RUSTFLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Possible log types:
 
 - [changed] `drone new` generates a more IDE-friendly project with all rustflags
   stored in `.cargo/config`
+- [deprecated] `drone env` command is now deprecated
 
 ### v0.13.0 (2020-11-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### v0.13.1 (2020-12-05)
+
+- [changed] `drone new` generates a more IDE-friendly project with all rustflags
+  stored in `.cargo/config`
+
 ### v0.13.0 (2020-11-28)
 
 - [added] Added mandatory option `linker.platform` to `Drone.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "drone"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "drone-config"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["config"]
 
 [package]
 name = "drone"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Valentine Valyaeff <valentine.valyaeff@gmail.com>"]
 edition = "2018"
 resolver = "2"
@@ -36,7 +36,7 @@ CLI utility for Drone, an Embedded Operating System.
 maintenance = { status = "actively-developed" }
 
 [dependencies.drone-config]
-version = "=0.13.0"
+version = "=0.13.1"
 path = "config"
 
 [dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["resolver"]
 
 [package]
 name = "drone-config"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Valentine Valyaeff <valentine.valyaeff@gmail.com>"]
 edition = "2018"
 resolver = "2"

--- a/src/cmd/env.rs
+++ b/src/cmd/env.rs
@@ -1,11 +1,13 @@
 //! `drone env` command.
 
-use crate::cli::EnvCmd;
+use crate::{cli::EnvCmd, color::Color};
+use ansi_term::Color::Yellow;
 use anyhow::{anyhow, bail, Result};
 use std::{env, os::unix::process::CommandExt, process::Command};
 
 /// Runs `drone env` command.
-pub fn run(cmd: EnvCmd) -> Result<()> {
+pub fn run(cmd: EnvCmd, color: Color) -> Result<()> {
+    eprintln!("{}: `drone env` command is deprecated", color.bold_fg("warning", Yellow));
     let EnvCmd { target, command } = cmd;
     let mut iter = command.iter();
     if let Some(command) = iter.next() {

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -58,7 +58,7 @@ pub fn run(cmd: NewCmd, color: Color) -> Result<()> {
     drone_toml(&path, device, flash_size, ram_size, &heap, probe, log, &registry, color)?;
     justfile(&path, device, &registry, color)?;
     rust_toolchain(&path, &toolchain, &registry, color)?;
-    cargo_config(&path, &registry, color)?;
+    cargo_config(&path, device, &registry, color)?;
     gitignore(&path, &registry, color)?;
 
     Ok(())
@@ -240,12 +240,12 @@ fn rust_toolchain(
     Ok(())
 }
 
-fn cargo_config(path: &Path, registry: &Registry<'_>, color: Color) -> Result<()> {
+fn cargo_config(path: &Path, device: &Device, registry: &Registry<'_>, color: Color) -> Result<()> {
     let path = path.join(".cargo");
     create_dir(&path)?;
     let path = path.join("config");
     let mut file = File::create(&path)?;
-    file.write_all(registry.new_cargo_config()?.as_bytes())?;
+    file.write_all(registry.new_cargo_config(device)?.as_bytes())?;
     print_created(".cargo/config", color);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl Cli {
             .filter(None, Level::Warn.to_level_filter())
             .try_init()?;
         match cmd {
-            Cmd::Env(cmd) => cmd::env(cmd),
+            Cmd::Env(cmd) => cmd::env(cmd, color),
             Cmd::Flash(cmd) => cmd::flash(cmd),
             Cmd::Gdb(cmd) => cmd::gdb(cmd),
             Cmd::Heap(cmd) => cmd::heap(cmd, color),

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -189,13 +189,7 @@ impl Registry<'_> {
 
     /// Renders `Justfile`.
     pub fn new_justfile(&self, device: &Device) -> Result<String> {
-        let data = json!({
-            "device_target": device.target,
-            "platform_flag_name": device.platform_crate.krate.flag_name(),
-            "bindings_flag_name": device.bindings_crate.krate.flag_name(),
-            "platform_flag": device.platform_crate.flag,
-            "bindings_flag": device.bindings_crate.flag,
-        });
+        let data = json!({ "device_target": device.target });
         helpers::clear_vars();
         Ok(self.0.render("new/Justfile", &data)?)
     }
@@ -208,9 +202,16 @@ impl Registry<'_> {
     }
 
     /// Renders `.cargo/config`.
-    pub fn new_cargo_config(&self) -> Result<String> {
+    pub fn new_cargo_config(&self, device: &Device) -> Result<String> {
+        let data = json!({
+            "device_target": device.target,
+            "platform_flag_name": device.platform_crate.krate.flag_name(),
+            "bindings_flag_name": device.bindings_crate.krate.flag_name(),
+            "platform_flag": device.platform_crate.flag,
+            "bindings_flag": device.bindings_crate.flag,
+        });
         helpers::clear_vars();
-        Ok(self.0.render("new/_cargo/config", &())?)
+        Ok(self.0.render("new/_cargo/config", &data)?)
     }
 
     /// Renders `.gitignore`.

--- a/src/templates/new/Justfile.hbs
+++ b/src/templates/new/Justfile.hbs
@@ -1,4 +1,3 @@
-export DRONE_RUSTFLAGS := '--cfg {{platform_flag_name}}="{{platform_flag}}" --cfg {{bindings_flag_name}}="{{bindings_flag}}"'
 target := '{{device_target}}'
 features := ''
 name := `basename "$(pwd)"`
@@ -20,39 +19,38 @@ fmt:
 
 # Check the source code for mistakes
 lint:
-	drone env \{{target}} -- cargo clippy --features "\{{features}}"
+	cargo clippy --features "\{{features}}"
 
 # Build the binary
 build:
-	drone env \{{target}} -- cargo build --features "\{{features}}" --release
+	cargo build --features "\{{features}}" --release
 
 # Build the documentation
 doc:
-	drone env \{{target}} -- cargo doc --features "\{{features}}"
+	cargo doc --features "\{{features}}"
 
 # Open the documentation in a browser
 doc-open: doc
-	drone env \{{target}} -- cargo doc --features "\{{features}}" --open
+	cargo doc --features "\{{features}}" --open
 
 # Run the tests
 test:
-	drone env -- cargo test --features "std \{{features}}"
+	cargo test --features "std \{{features}}" \
+		--target=$(rustc --version --verbose | sed -n '/host/{s/.*: //;p}')
 
 # Display information from the binary
 dump: build
-	drone env \{{target}} -- cargo objdump --target \{{target}} \
-		--features "\{{features}}" --release --bin \{{name}} -- \
-		--disassemble --demangle --full-contents -all-headers --syms | pager
+	cargo objdump --features "\{{features}}" --release --bin \{{name}} -- \
+		--disassemble --demangle --full-contents --all-headers --syms \
+		| pager
 
 # Display the sizes of sections inside the binary
 size +args='': build
-	drone env \{{target}} -- cargo size --target \{{target}} \
-		--features "\{{features}}" --release --bin \{{name}} -- \{{args}}
+	cargo size --features "\{{features}}" --release --bin \{{name}} -- \{{args}}
 
 # Display the result of macro expansion
 expand:
-	drone env \{{target}} -- cargo rustc --target \{{target}} \
-		--features "\{{features}}" --lib -- -Z unstable-options --pretty=expanded
+	cargo rustc --features "\{{features}}" --lib -- -Z unstable-options --pretty=expanded
 
 # Assert the reset signal
 reset:

--- a/src/templates/new/_cargo/config.hbs
+++ b/src/templates/new/_cargo/config.hbs
@@ -1,4 +1,13 @@
-[target.'cfg(target_os = "none")']
+[build]
+target = '{{device_target}}'
 rustflags = [
-    "-C", "linker=drone-ld",
+    '--cfg', '{{platform_flag_name}}="{{platform_flag}}"',
+    '--cfg', '{{bindings_flag_name}}="{{bindings_flag}}"',
+]
+
+[target.{{device_target}}]
+rustflags = [
+    '--cfg', '{{platform_flag_name}}="{{platform_flag}}"',
+    '--cfg', '{{bindings_flag_name}}="{{bindings_flag}}"',
+    '-C', 'linker=drone-ld',
 ]


### PR DESCRIPTION
Make new projects generated by `drone new` more IDE-friendly by moving all RUSTFLAGS configuration to `.cargo/config`.

One minor drawback of this change is that some configuration options are duplicated within `.cargo/config` file because of cargo issue https://github.com/rust-lang/cargo/issues/5376. Also the compile target is stored in both `.cargo/config` and `Justfile`.