### PR TITLE
Add support for customized text start address

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub memory: Memory,
     pub heap: Heap,
     pub linker: Linker,
+    pub text: Option<Text>,
     pub probe: Option<Probe>,
     pub log: Option<Log>,
 }
@@ -69,6 +70,13 @@ pub struct HeapPool {
     #[serde(deserialize_with = "deserialize_size")]
     pub block: u32,
     pub capacity: u32,
+}
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Text {
+    pub start: u32,
 }
 
 #[non_exhaustive]

--- a/src/templates/layout.ld.hbs
+++ b/src/templates/layout.ld.hbs
@@ -30,7 +30,13 @@ SECTIONS
     } > FLASH
 {{~ /if}}
 
-    .text :
+{{~ #if config.text.start }}
+    _stext = {{addr config.text.start}};
+{{~ else}}
+    _stext = ADDR(.vtable) + SIZEOF(.vtable);
+{{~ /if}}
+
+    .text _stext:
     {
         *(.text.reset);
         *(.text.*);


### PR DESCRIPTION
I wanna use STM32F405 3rd and 4th flash sector as EEPROM, so text start address has to be customized.