### PR TITLE
Update the openocd repo url

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,7 +66,7 @@
         "shallow": true,
         "submodules": true,
         "type": "git",
-        "url": "git://git.code.sf.net/p/openocd/code"
+        "url": "https://github.com/openocd-org/openocd.git"
       },
       "original": {
         "ref": "v0.11.0",
@@ -74,7 +74,7 @@
         "shallow": true,
         "submodules": true,
         "type": "git",
-        "url": "git://git.code.sf.net/p/openocd/code"
+        "url": "https://github.com/openocd-org/openocd.git"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     };
     openocd = {
       type = "git";
-      url = "git://git.code.sf.net/p/openocd/code";
+      url = "https://github.com/openocd-org/openocd.git";
       shallow = true;
       submodules = true;
       ref = "v0.11.0";


### PR DESCRIPTION
Running "nix develop" it complaints that the "git://git.code.sf.net/p/openocd/code" repo does not have the `v0.11.0` tag.